### PR TITLE
Add lab for deploying Apache NiFi via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ cd ansible/lab-05/
 ansible-playbook deploy-web-content.yml
 ```
 
+### lab-08
+
+```
+ansible-galaxy collection install community.docker
+cd ansible/lab-08/
+ansible-playbook -i ../inventory/ansible-nodes deploy-nifi.yml \
+  -e "nifi_admin_password=SomeSecurePassword"
+```
+
 ## lab-06 - Please don't push your AWS key on github
 
 Lab to create instances on AWS. 

--- a/lab-08/README.md
+++ b/lab-08/README.md
@@ -1,0 +1,27 @@
+# Lab 08 - Deploy Apache NiFi with Docker
+
+This lab provisions a single-node Apache NiFi instance by running the official Docker image on your target host.
+
+## Prerequisites
+- An inventory entry for the machine that should run NiFi. Assign the host to a `nifi` group, for example:
+  ```ini
+  [nifi]
+  nifi-node ansible_host=10.0.0.10 ansible_user=ec2-user
+  ```
+- Python 3 and network access to download Docker packages on the managed host.
+- Install the required Ansible collection on the control node:
+  ```bash
+  ansible-galaxy collection install community.docker
+  ```
+
+## Usage
+```bash
+cd ansible/lab-08/
+ansible-playbook -i ../inventory/ansible-nodes deploy-nifi.yml \
+  -e "nifi_admin_password=SomeSecurePassword"
+```
+
+The playbook will install Docker, start the service, pull the latest `apache/nifi` container image, and expose NiFi over HTTPS on port `8443`. Use the credentials provided through `nifi_admin_username` and `nifi_admin_password` to sign in.
+
+### Customisation
+The defaults for the container live in `roles/nifi_single_node/defaults/main.yml`. Override them with `-e` or group variables to adjust the exposed port, container name, or data directory.

--- a/lab-08/deploy-nifi.yml
+++ b/lab-08/deploy-nifi.yml
@@ -1,0 +1,9 @@
+---
+- name: Deploy a single-node Apache NiFi instance on Docker
+  hosts: nifi
+  become: true
+  collections:
+    - community.docker
+  roles:
+    - docker_runtime
+    - nifi_single_node

--- a/lab-08/roles/docker_runtime/tasks/main.yml
+++ b/lab-08/roles/docker_runtime/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Install Docker dependencies on RedHat-based systems
+  ansible.builtin.yum:
+    name:
+      - docker
+      - python3-pip
+    state: present
+  when: ansible_facts.os_family == "RedHat"
+
+- name: Install Docker dependencies on Debian-based systems
+  ansible.builtin.apt:
+    name:
+      - docker.io
+      - python3-pip
+    state: present
+    update_cache: true
+  when: ansible_facts.os_family == "Debian"
+
+- name: Ensure Docker service is enabled and running
+  ansible.builtin.service:
+    name: docker
+    state: started
+    enabled: true
+
+- name: Install Docker SDK for Python
+  ansible.builtin.pip:
+    name: docker
+    state: present
+    executable: pip3

--- a/lab-08/roles/nifi_single_node/defaults/main.yml
+++ b/lab-08/roles/nifi_single_node/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+nifi_docker_image: "apache/nifi:latest"
+nifi_container_name: "nifi"
+nifi_ui_port: 8443
+nifi_data_dir: "/opt/nifi/data"
+nifi_admin_username: "nifiadmin"
+nifi_admin_password: "ChangeMe123!"

--- a/lab-08/roles/nifi_single_node/tasks/main.yml
+++ b/lab-08/roles/nifi_single_node/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Ensure NiFi data directories exist
+  ansible.builtin.file:
+    path: "{{ nifi_data_dir }}/{{ item }}"
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: "0775"
+  loop:
+    - state
+    - flowfile_repository
+    - database_repository
+    - content_repository
+    - conf
+
+- name: Pull Apache NiFi container image
+  community.docker.docker_image:
+    name: "{{ nifi_docker_image }}"
+    source: pull
+
+- name: Run Apache NiFi container
+  community.docker.docker_container:
+    name: "{{ nifi_container_name }}"
+    image: "{{ nifi_docker_image }}"
+    state: started
+    recreate: true
+    restart_policy: unless-stopped
+    published_ports:
+      - "{{ nifi_ui_port }}:8443"
+    volumes:
+      - "{{ nifi_data_dir }}/state:/opt/nifi/nifi-current/state"
+      - "{{ nifi_data_dir }}/flowfile_repository:/opt/nifi/nifi-current/flowfile_repository"
+      - "{{ nifi_data_dir }}/database_repository:/opt/nifi/nifi-current/database_repository"
+      - "{{ nifi_data_dir }}/content_repository:/opt/nifi/nifi-current/content_repository"
+      - "{{ nifi_data_dir }}/conf:/opt/nifi/nifi-current/conf"
+    env:
+      SINGLE_USER_CREDENTIALS_USERNAME: "{{ nifi_admin_username }}"
+      SINGLE_USER_CREDENTIALS_PASSWORD: "{{ nifi_admin_password }}"
+      NIFI_WEB_HTTPS_PORT: "{{ nifi_ui_port }}"


### PR DESCRIPTION
## Summary
- add lab-08 playbook and roles that install Docker and run the apache/nifi container
- provide lab-specific documentation for prerequisites, usage, and customization
- update the main README with quick commands for running the new lab

## Testing
- not run

